### PR TITLE
Add DisQuest-ORM and DisQuest-Postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.idea
+.dccache

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# EasyBot-Plugins
+
+The official first party plugins for EasyBot by Chisaku-Dev
+
+# Installing
+
+Just take these plugins, and drag and drop the desired plugins into the cogs folder. That simple. 
+
+# DisQuest
+
+The DisQuest cog contain 3 versions: the original version, a orm-based version (more secure) that uses a local database, and a PostgreSQL version. The original version is marked as `disquest.py`, whille the other 2 are marked as `disquest-orm.py` and `disquest-postgres.py`. `disquest-orm.py` is a rewritten version that uses an ORM (Object Relational Mapper) to store the data, while `disquest-postgres.py` is a rewritten version that relies on a PostgreSQL database.
+
+## DisQuest and DisQuest-ORM 
+
+Both do not need any setup. Make sure to create a folder called `disquest` and that's it
+
+## DisQuest-Postgres
+
+This version is meant for production use, where high read/write speeds are needed. SQLite3 frequently locks up when having tons of connections, thus making it not suitable for production use. To get started, download the [PostgreSQL Server](https://www.postgresql.org/) and if you wish, [pgAdmin4](https://www.pgadmin.org/) and psql (if you are using an installer, both pgAdmin4 and psql would be included if you selected them). Alternatively, you can use the Docker version [here](https://hub.docker.com/_/postgres). 
+
+Once installed, open up a query console and run this query: 
+
+```sql
+CREATE DATABASE disquest;
+```
+
+Once done, that's it. The cog will take care of the rest

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Once installed, open up a query console and run this query:
 CREATE DATABASE disquest;
 ```
 
-Once done, that's it. The cog will take care of the rest
+Once done, that's it. The cog will take care of the rest. And also as a side note, DisQuest-Postgres is the exact same version used by [Rin](https://github.com/No767/Rin) and [Kumiko](https://github.com/No767/Kumiko)

--- a/README.md
+++ b/README.md
@@ -24,4 +24,6 @@ Once installed, open up a query console and run this query:
 CREATE DATABASE disquest;
 ```
 
+Make sure to also go to the `disquest-postgres.py` file, and make a `.env file`. Add the following: `Postgres_Password`, `Postgres_Server_IP`, and `Postgres_Username`. The password and username is the account that you are going to use to access the database, and the server ip address can be either set as a IPv4 address, or if you are hosting it locally, `127.0.0.1`. Note that if you hosting the database somewhere else (like on AWS, Azure, or GCP), you will need to set the server ip address to the public ip address of the server.
+
 Once done, that's it. The cog will take care of the rest. And also as a side note, DisQuest-Postgres is the exact same version used by [Rin](https://github.com/No767/Rin) and [Kumiko](https://github.com/No767/Kumiko)

--- a/chat.py
+++ b/chat.py
@@ -1,5 +1,4 @@
 from discord.ext import commands
-import discord
 import json
 
 class Chat(commands.Cog):

--- a/disquest-orm.py
+++ b/disquest-orm.py
@@ -1,0 +1,190 @@
+import math
+import os
+import random
+
+import discord
+from discord.ext import commands
+from sqlalchemy import (Column, Integer, MetaData, Table, create_engine, func,
+                        select)
+
+
+class helper:
+    def fast_embed(content):
+        colors = [0x8B77BE, 0xA189E2, 0xCF91D1, 0x5665AA, 0xA3A3D2]
+        selector = random.choice(colors)
+        return discord.Embed(description=content, color=selector)
+
+
+class disaccount:
+    def __init__(self, ctx):
+        self.id = ctx.author.id
+        self.gid = ctx.guild.id
+
+    def getxp(self):
+        meta = MetaData()
+        engine = create_engine("sqlite:///disquest/user.db")
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        while True:
+            s = select(Column("xp", Integer)).where(
+                users.c.id == self.id, users.c.gid == self.gid
+            )
+            results = conn.execute(s)
+            xp = results.fetchone()
+
+            if xp == None:
+                ins = users.insert().values(id=self.id, gid=self.gid, xp=0)
+                conn.execute(ins)
+            else:
+                xp = xp[0]
+                break
+        conn.close()
+        return xp
+
+    def setxp(self, xp):
+        meta = MetaData()
+        engine = create_engine("sqlite:///disquest/user.db")
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        update_values = users.update().values(xp=xp, id=self.id, gid=self.gid)
+        conn.execute(update_values)
+        conn.close()
+
+    def addxp(self, offset):
+        pxp = self.getxp()
+        pxp += offset
+        self.setxp(pxp)
+
+
+class lvl:
+    def near(xp):
+        return round(xp / 100)
+
+    def next(xp):
+        return math.ceil(xp / 100)
+
+    def cur(xp):
+        return int(xp / 100)
+
+
+class DisQuest(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        os.chdir(os.path.dirname(__file__))
+        meta = MetaData()
+        engine = create_engine("sqlite:///disquest/user.db")
+        Table(
+            "user.db",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        meta.create_all(engine)
+
+    @commands.command(
+        name="mylvl",
+        help="Displays your activity level!",
+    )
+    async def mylvl(self, ctx):
+        user = disaccount(ctx)
+        xp = user.getxp()
+        await ctx.channel.send(
+            embed=helper.fast_embed(
+                f"""User: {ctx.author.mention}
+        LVL. {lvl.cur(xp)}
+        XP {xp}/{lvl.next(xp)*100}"""
+            )
+        )
+
+    @commands.command(
+        name="rank", help="Displays the most active members of your server!"
+    )
+    async def rank(self, ctx):
+        gid = discord.Guild.id
+        meta = MetaData()
+        engine = create_engine("sqlite:///disquest/user.db")
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        s = (
+            select(Column("id", Integer), Column("xp", Integer))
+            .filter((users.c.gid.is_(gid)))
+            .order_by(users.c.xp.desc())
+        )
+        results = conn.execute(s).fetchall()
+        members = list(results.fetchall())
+        for i, mem in enumerate(members):
+            members[
+                i
+            ] = f"{i}. {(await self.bot.fetch_user(mem[0])).name} | XP. {mem[1]}\n"
+        await ctx.send(
+            embed=helper.fast_embed(f"**Server Rankings**\n{''.join(members)}")
+        )
+
+    @commands.command(
+        name="globalrank",
+        help="Displays the most active members of all servers that this bot is connected to!",
+    )
+    async def grank(self, ctx):
+        meta = MetaData()
+        engine = create_engine("sqlite:///disquest/user.db")
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        s = (
+            select(Column("id", Integer), func.sum(users.c.xp).label("txp"))
+            .group_by(users.c.id)
+            .order_by(users.c.xp.desc())
+        )
+        results = conn.execute(s).fetchall()
+        members = list(results)
+        for i, mem in enumerate(members):
+            members[
+                i
+            ] = f"{i}. {(await self.bot.fetch_user(mem[0])).name} | XP. {mem[1]}\n"
+        await ctx.send(
+            embed=helper.fast_embed(f"**Global Rankings**\n{''.join(members)}")
+        )
+
+    @commands.Cog.listener()
+    async def on_message(self, ctx):
+        if ctx.author.bot:
+            return
+        user = disaccount(ctx)
+        reward = random.randint(0, 20)
+        user.addxp(reward)
+        xp = user.getxp()
+        if lvl.near(xp) * 100 in range(xp - reward, xp):
+            await ctx.channel.send(
+                embed=helper.fast_embed(
+                    f"{ctx.author.mention} has reached LVL. {lvl.cur(xp)}"
+                ),
+                delete_after=10,
+            )
+
+
+def setup(bot):
+    bot.add_cog(DisQuest(bot))

--- a/disquest-postgres.py
+++ b/disquest-postgres.py
@@ -15,7 +15,8 @@ Password = os.getenv("Postgres_Password")
 IP = os.getenv("Postgres_Server_IP")
 Username = os.getenv("Postgres_Username")
 
-# This uses a backend PostgreSQL DB instead of SQLite3. This is recommended over the SQLite3 option, since this allows faster concurrent read/writes and doesn't lock up the database as easily as the SQLite3 version
+# This uses a backend PostgreSQL DB instead of SQLite3. This is recommended over the SQLite3 option
+# Since this allows faster concurrent read/writes and doesn't lock up the database as easily as the SQLite3 version
 # MAKE SURE YOU HAVE A POSTGRES SERVER RUNNING WTIH THE DB NAMED "disquest" AND THE INFO STORED IN A .ENV FILE
 # INSTALL THE LIBS AS NEEDED
 class helper:

--- a/disquest-postgres.py
+++ b/disquest-postgres.py
@@ -1,0 +1,210 @@
+import math
+import os
+import random
+
+import discord
+from discord.ext import commands
+from sqlalchemy import (Column, Integer, MetaData, Table, create_engine, func,
+                        select)
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+Password = os.getenv("Postgres_Password")
+IP = os.getenv("Postgres_Server_IP")
+Username = os.getenv("Postgres_Username")
+
+# This uses a backend PostgreSQL DB instead of SQLite3. This is recommended over the SQLite3 option, since this allows faster concurrent read/writes and doesn't lock up the database as easily as the SQLite3 version
+# MAKE SURE YOU HAVE A POSTGRES SERVER RUNNING WTIH THE DB NAMED "disquest" AND THE INFO STORED IN A .ENV FILE
+# INSTALL THE LIBS AS NEEDED
+class helper:
+    def fast_embed(content):
+        colors = [0x8B77BE, 0xA189E2, 0xCF91D1, 0x5665AA, 0xA3A3D2]
+        selector = random.choice(colors)
+        return discord.Embed(description=content, color=selector)
+
+
+class disaccount:
+    def __init__(self, ctx):
+        self.id = ctx.author.id
+        self.gid = ctx.guild.id
+
+    def getxp(self):
+        meta = MetaData()
+        engine = create_engine(
+            f"postgresql+psycopg2://{Username}:{Password}@{IP}:5432/disquest"
+        )
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        while True:
+            s = select(Column("xp", Integer)).where(
+                users.c.id == self.id, users.c.gid == self.gid
+            )
+            results = conn.execute(s)
+            xp = results.fetchone()
+
+            if xp == None:
+                ins = users.insert().values(id=self.id, gid=self.gid, xp=0)
+                conn.execute(ins)
+            else:
+                xp = xp[0]
+                break
+        conn.close()
+        return xp
+
+    def setxp(self, xp):
+        meta = MetaData()
+        engine = create_engine(
+            f"postgresql+psycopg2://{Username}:{Password}@{IP}:5432/disquest"
+        )
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        update_values = users.update().values(xp=xp, id=self.id, gid=self.gid)
+        conn.execute(update_values)
+        conn.close()
+
+    def addxp(self, offset):
+        pxp = self.getxp()
+        pxp += offset
+        self.setxp(pxp)
+
+
+class lvl:
+    def near(xp):
+        return round(xp / 100)
+
+    def next(xp):
+        return math.ceil(xp / 100)
+
+    def cur(xp):
+        return int(xp / 100)
+
+
+class DisQuest(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        os.chdir(os.path.dirname(__file__))
+        meta = MetaData()
+        engine = create_engine(
+            f"postgresql+psycopg2://{Username}:{Password}@{IP}:5432/disquest"
+        )
+        Table(
+            "user.db",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        meta.create_all(engine)
+
+    @commands.command(
+        name="mylvl",
+        help="Displays your activity level!",
+    )
+    async def mylvl(self, ctx):
+        user = disaccount(ctx)
+        xp = user.getxp()
+        await ctx.channel.send(
+            embed=helper.fast_embed(
+                f"""User: {ctx.author.mention}
+        LVL. {lvl.cur(xp)}
+        XP {xp}/{lvl.next(xp)*100}"""
+            )
+        )
+
+    @commands.command(
+        name="rank", help="Displays the most active members of your server!"
+    )
+    async def rank(self, ctx):
+        gid = discord.Guild.id
+        meta = MetaData()
+        engine = create_engine(
+            f"postgresql+psycopg2://{Username}:{Password}@{IP}:5432/disquest"
+        )
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        s = (
+            select(Column("id", Integer), Column("xp", Integer))
+            .filter((users.c.gid.is_(gid)))
+            .order_by(users.c.xp.desc())
+        )
+        results = conn.execute(s).fetchall()
+        members = list(results.fetchall())
+        for i, mem in enumerate(members):
+            members[
+                i
+            ] = f"{i}. {(await self.bot.fetch_user(mem[0])).name} | XP. {mem[1]}\n"
+        await ctx.send(
+            embed=helper.fast_embed(f"**Server Rankings**\n{''.join(members)}")
+        )
+
+    @commands.command(
+        name="globalrank",
+        help="Displays the most active members of all servers that this bot is connected to!",
+    )
+    async def grank(self, ctx):
+        meta = MetaData()
+        engine = create_engine(
+            f"postgresql+psycopg2://{Username}:{Password}@{IP}:5432/disquest"
+        )
+        users = Table(
+            "user",
+            meta,
+            Column("id", Integer),
+            Column("gid", Integer),
+            Column("xp", Integer),
+        )
+        conn = engine.connect()
+        s = (
+            select(Column("id", Integer), func.sum(users.c.xp).label("txp"))
+            .group_by(users.c.id)
+            .order_by(users.c.xp.desc())
+        )
+        results = conn.execute(s).fetchall()
+        members = list(results)
+        for i, mem in enumerate(members):
+            members[
+                i
+            ] = f"{i}. {(await self.bot.fetch_user(mem[0])).name} | XP. {mem[1]}\n"
+        await ctx.send(
+            embed=helper.fast_embed(f"**Global Rankings**\n{''.join(members)}")
+        )
+
+    @commands.Cog.listener()
+    async def on_message(self, ctx):
+        if ctx.author.bot:
+            return
+        user = disaccount(ctx)
+        reward = random.randint(0, 20)
+        user.addxp(reward)
+        xp = user.getxp()
+        if lvl.near(xp) * 100 in range(xp - reward, xp):
+            await ctx.channel.send(
+                embed=helper.fast_embed(
+                    f"{ctx.author.mention} has reached LVL. {lvl.cur(xp)}"
+                ),
+                delete_after=10,
+            )
+
+
+def setup(bot):
+    bot.add_cog(DisQuest(bot))


### PR DESCRIPTION
The ORM version is modified to use SQLAlchemy, thus preventing SQL injection attacks (since we are storing user ids and server ids). It still uses SQLite3 for easier setup. The Postgres version is written to use PostgreSQL (could also be tweaked for MySQL or MSSQL), and is better suited in production environments, where high concurrency and read/write speeds are needed 